### PR TITLE
Fix main entry, so it's compatible with other resolvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	],
 	"description": "An ESnext spec-compliant `Array.prototype.flatten` shim/polyfill/replacement that works as far down as ES3.",
 	"license": "MIT",
-	"main": "./",
+	"main": "index.js",
 	"scripts": {
 		"prepublish": "safe-publish-latest",
 		"pretest": "npm run --silent lint && evalmd README.md",


### PR DESCRIPTION
This package can't be included right now with webpack (Jest also has a similar issue).

While it's a bug in webpack, this package is not usable by any web app right now that bundles with webpack.
https://github.com/webpack/enhanced-resolve/issues/123

By switching the "main" entry in package.json, this package will be compatible with all resolvers (and also conform to the same pattern as every other repo in the es-shim org)